### PR TITLE
chore(jdk): Bumps java8 to use AWS Corretto

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,7 +13,7 @@ package:
 
 provider:
   name: aws
-  runtime: java8
+  runtime: java8.al2
   stage: ${self:custom.stage}
   region: ${self:custom.region}
   deploymentBucket: ${self:custom.deploymentBucket}

--- a/thundra-lambda-warmup-cloudformation-template.yaml
+++ b/thundra-lambda-warmup-cloudformation-template.yaml
@@ -106,7 +106,7 @@ Resources:
       Code:
         S3Bucket: !Sub "thundra-dist-${AWS::Region}"
         S3Key: "thundra-lambda-warmup.jar"
-      Runtime: java8
+      Runtime: java8.al2
       Timeout:
         Ref: TimeoutParameter
       MemorySize:


### PR DESCRIPTION
* AWS is deprecating the Java 8 OpenJDK runtime in favour of the AWS
  Corretto (`java8.al2`) runtime.
* This commit bumps this version in advance to allow testing prior to the forced cut-over

See Also:
* https://aws.amazon.com/blogs/compute/announcing-migration-of-the-java-8-runtime-in-aws-lambda-to-amazon-corretto/